### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ CLEAN.include('**/*.gem', '**/*.rbc')
 namespace :gem do
   desc "Create the ffi-win32-extensions gem"
   task :create => [:clean] do
-    require 'rubygems/package'
+    require 'rubygems/package' unless defined?(Gem::Package)
     spec = eval(IO.read('ffi-win32-extensions.gemspec'))
     spec.signing_key = File.join(Dir.home, '.ssh', 'gem-private_key.pem')
     Gem::Package.build(spec, true)

--- a/lib/ffi/win32/extensions.rb
+++ b/lib/ffi/win32/extensions.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require 'ffi' unless defined?(FFI)
 
 class FFI::Pointer
   # Returns an array of strings for char** types.


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>