### PR TITLE
Updating ffi support

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -7,6 +7,11 @@ set -ue
 export USER="root"
 export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 
+echo "--- Updating Ruby Gems"
+gem install rubygems-update
+update_rubygems
+gem update --system
+
 echo "--- bundle install"
 
 bundle config --local path vendor/bundle

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -17,4 +17,4 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-buster
+        image: ruby:3.0

--- a/ffi-win32-extensions.gemspec
+++ b/ffi-win32-extensions.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir["test/test*"]
   spec.files      = Dir["**/*"].reject { |f| f.include?("git") }
 
-  spec.add_dependency("ffi")
+  spec.add_dependency("ffi", ">= 1.15.5", "<= 1.17.0")
 
   spec.description = <<-EOF
     The ffi-win32-extensions library adds additional methods to the FFI


### PR DESCRIPTION
### Description

This gem hasn't been updated in a while and it's causing Chef-18 to die in testing. Updating here

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG