### PR TITLE
Fix ffi gem dependency

### DIFF
--- a/ffi-win32-extensions.gemspec
+++ b/ffi-win32-extensions.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir["test/test*"]
   spec.files      = Dir["**/*"].reject { |f| f.include?("git") }
 
-  spec.add_dependency("ffi", ">= 1.15.5", "<= 1.17.0")
+  spec.add_dependency("ffi", "~> 1.15")
 
   spec.description = <<-EOF
     The ffi-win32-extensions library adds additional methods to the FFI


### PR DESCRIPTION
### Description

The `ffi` version constraint should not exclude future compatible `ffi` versions.

### Issues Resolved

It currently prevents the update to ffi-1.17.2.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG